### PR TITLE
system-exclude.txt: Use a wildcard for Brave profiles

### DIFF
--- a/usr/local/bin/system-exclude.txt
+++ b/usr/local/bin/system-exclude.txt
@@ -56,9 +56,9 @@
 /home/*/.mozilla/firefox/*/favicons.sqlite
 
 # Brave Browser
-/home/*/.config/BraveSoftware/Brave-Browser/Default/Local Storage
-/home/*/.config/BraveSoftware/Brave-Browser/Default/Session Storage
-/home/*/.config/BraveSoftware/Brave-Browser/Default/Favicons
+/home/*/.config/BraveSoftware/Brave-Browser/*/Local Storage
+/home/*/.config/BraveSoftware/Brave-Browser/*/Session Storage
+/home/*/.config/BraveSoftware/Brave-Browser/*/Favicons
 
 # Electron apps
 /home/*/.config/**/Cache


### PR DESCRIPTION
Multiple profiles can be created and even `Default` as a profile name may not exist.

I have not tested it, but as you create more profiles in Brave, they got different names, not `Default`. I have many profile directories named `Profile N`.

I'm using Brave as Snap, so the path in my case is not 
`/home/<user>/.config/BraveSoftware`
but
`/home/<user>/snap/.config/BraveSoftware`

(maybe it would be worth to include it 🙂)

Finally, when I run `ncdu` on the Brave directory, I find that some profiles has other directories that contain hundreds of MB, like:
- `/IndexedDb`
- `/Service Worker`

but I'm not sure which ones can be excluded to still keep a healthy profile backup, so upon restore all open windows and tabs and extensions are in place.

Cheers!